### PR TITLE
Add GitHub ribbon

### DIFF
--- a/2.6/index.html
+++ b/2.6/index.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="utf-8">
     <link href="https://netdna.bootstrapcdn.com/bootstrap/3.0.2/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.min.css" />
+    <!--[if lt IE 9]>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.ie.min.css" />
+    <![endif]-->
     <link rel="icon" href="favicon.ico">
     <link rel="icon" href="wheel.png">
     <style>
@@ -129,6 +133,7 @@ except ImportError:
         <footer>
             <p>Code on <a href="https://github.com/hugovk/drop-python">GitHub</a>.</p>
             <p>Last updated <span ng-bind="last_update"></span>. (Updated hourly.)</p>
+            <a class="github-fork-ribbon no-box-sizing" href="https://github.com/hugovk/drop-python" target="_blank" title="Fork me on GitHub">Fork me on GitHub</a>
         </footer>
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.10/angular.min.js"></script>

--- a/2.6/index.html
+++ b/2.6/index.html
@@ -18,6 +18,13 @@
         a.btn:last-child{border-bottom-width: 1px; border-bottom-left-radius: 5px; border-bottom-right-radius: 5px;}
         pre {text-align: left;}
         footer{text-align: center;}
+        .github-fork-ribbon:before {
+            background-color: #090;
+        }
+        .github-fork-ribbon.no-box-sizing:before,
+        .github-fork-ribbon.no-box-sizing:after {
+            box-sizing: content-box;
+        }
     </style>
     <title>Drop Python 2.6</title>
 </head>

--- a/3.2/index.html
+++ b/3.2/index.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="utf-8">
     <link href="https://netdna.bootstrapcdn.com/bootstrap/3.0.2/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.min.css" />
+    <!--[if lt IE 9]>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.ie.min.css" />
+    <![endif]-->
     <link rel="icon" href="favicon.ico">
     <link rel="icon" href="wheel.png">
     <style>
@@ -120,6 +124,7 @@ except ImportError:
         <footer>
             <p>Code on <a href="https://github.com/hugovk/drop-python">GitHub</a>.</p>
             <p>Last updated <span ng-bind="last_update"></span>. (Updated hourly.)</p>
+            <a class="github-fork-ribbon no-box-sizing" href="https://github.com/hugovk/drop-python" target="_blank" title="Fork me on GitHub">Fork me on GitHub</a>
         </footer>
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.10/angular.min.js"></script>

--- a/3.2/index.html
+++ b/3.2/index.html
@@ -18,6 +18,13 @@
         a.btn:last-child{border-bottom-width: 1px; border-bottom-left-radius: 5px; border-bottom-right-radius: 5px;}
         pre {text-align: left;}
         footer{text-align: center;}
+        .github-fork-ribbon:before {
+            background-color: #090;
+        }
+        .github-fork-ribbon.no-box-sizing:before,
+        .github-fork-ribbon.no-box-sizing:after {
+            box-sizing: content-box;
+        }
     </style>
     <title>Drop Python 3.2</title>
 </head>

--- a/3.3/index.html
+++ b/3.3/index.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="utf-8">
     <link href="https://netdna.bootstrapcdn.com/bootstrap/3.0.2/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.min.css" />
+    <!--[if lt IE 9]>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.ie.min.css" />
+    <![endif]-->
     <link rel="icon" href="favicon.ico">
     <link rel="icon" href="wheel.png">
     <style>
@@ -117,6 +121,7 @@ except ImportError:
         <footer>
             <p>Code on <a href="https://github.com/hugovk/drop-python">GitHub</a>.</p>
             <p>Last updated <span ng-bind="last_update"></span>. (Updated hourly.)</p>
+            <a class="github-fork-ribbon no-box-sizing" href="https://github.com/hugovk/drop-python" target="_blank" title="Fork me on GitHub">Fork me on GitHub</a>
         </footer>
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.10/angular.min.js"></script>

--- a/3.3/index.html
+++ b/3.3/index.html
@@ -18,6 +18,13 @@
         a.btn:last-child{border-bottom-width: 1px; border-bottom-left-radius: 5px; border-bottom-right-radius: 5px;}
         pre {text-align: left;}
         footer{text-align: center;}
+        .github-fork-ribbon:before {
+            background-color: #090;
+        }
+        .github-fork-ribbon.no-box-sizing:before,
+        .github-fork-ribbon.no-box-sizing:after {
+            box-sizing: content-box;
+        }
     </style>
     <title>Drop Python 3.3</title>
 </head>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,13 @@
         a.btn:last-child{border-bottom-width: 1px; border-bottom-left-radius: 5px; border-bottom-right-radius: 5px;}
         pre {text-align: left;}
         footer{text-align: center;}
+        .github-fork-ribbon:before {
+            background-color: #090;
+        }
+        .github-fork-ribbon.no-box-sizing:before,
+        .github-fork-ribbon.no-box-sizing:after {
+            box-sizing: content-box;
+        }
     </style>
     <title>Drop Python</title>
 </head>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="utf-8">
     <link href="https://netdna.bootstrapcdn.com/bootstrap/3.0.2/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.min.css" />
+    <!--[if lt IE 9]>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.ie.min.css" />
+    <![endif]-->
     <link rel="icon" href="favicon.ico">
     <link rel="icon" href="3.2/wheel.png">
     <style>
@@ -67,6 +71,7 @@
         <footer>
             <p>Code on <a href="https://github.com/hugovk/drop-python">GitHub</a>.</p>
             <p>Last updated <span ng-bind="last_update"></span>. (Updated hourly.)</p>
+            <a class="github-fork-ribbon no-box-sizing" href="https://github.com/hugovk/drop-python" target="_blank" title="Fork me on GitHub">Fork me on GitHub</a>
         </footer>
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.10/angular.min.js"></script>


### PR DESCRIPTION
Changes proposed in this pull request:
- Add fork me on github ribbon
- Fix ribbon cut off by overriding bootstrap box-sizing from `border-box` to `content-box`

<img width="1438" alt="screen shot 2560-10-07 at 11 28 06 pm" src="https://user-images.githubusercontent.com/2629750/31309844-352c181c-abb7-11e7-8417-2c0e806d631a.png">

connected to https://github.com/hugovk/drop-python/issues/6