### PR TITLE
top-pypi-packages.json now has the packages in 'rows'

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -91,7 +91,7 @@ def get_top_packages():
     print('Getting packages...')
 
     with open('top-pypi-packages.json') as data_file:
-        packages = json.load(data_file)
+        packages = json.load(data_file)['rows']
 
     # Rename keys
     for package in packages:


### PR DESCRIPTION
https://github.com/hugovk/top-pypi-packages uses pypinfo, which from [12.0.0/13.0.0 onwards](https://github.com/ofek/pypinfo#changelog) changed the structure of the data. The packages are now in `'rows'`, there's new metadata about the Google BigQuery in `query`, and a `last_update` UTC timestamp.
