### PR TITLE
Version numbers are strings, not decimals. Fixes handling for 3.0

### DIFF
--- a/2.4/index.html
+++ b/2.4/index.html
@@ -144,9 +144,9 @@ except ImportError:
         .controller('wheelCtrl', function ($scope, $http) {
             $scope.init = function() {
                 $scope.eol = '19 December 2008';
-                $scope.version = 2.4;
-                $scope.major = parseInt($scope.version.toString()[0]);
-                $scope.minor = parseInt($scope.version.toString()[2]);
+                $scope.version = '2.4';
+                $scope.major = parseInt($scope.version[0]);
+                $scope.minor = parseInt($scope.version[2]);
                 $scope.next_minor = $scope.minor + 1;
                 $scope.next_version = $scope.major + ($scope.next_minor/10);
             };

--- a/2.5/index.html
+++ b/2.5/index.html
@@ -144,9 +144,9 @@ except ImportError:
         .controller('wheelCtrl', function ($scope, $http) {
             $scope.init = function() {
                 $scope.eol = '26 May 2011';
-                $scope.version = 2.5;
-                $scope.major = parseInt($scope.version.toString()[0]);
-                $scope.minor = parseInt($scope.version.toString()[2]);
+                $scope.version = '2.5';
+                $scope.major = parseInt($scope.version[0]);
+                $scope.minor = parseInt($scope.version[2]);
                 $scope.next_minor = $scope.minor + 1;
                 $scope.next_version = $scope.major + ($scope.next_minor/10);
             };

--- a/2.6/index.html
+++ b/2.6/index.html
@@ -177,8 +177,8 @@ set([1, 2, 3])  # This can be replaced...
             $scope.init = function() {
                 $scope.eol = '29 October 2013';
                 $scope.version = '2.6';
-                $scope.major = parseInt($scope.version.toString()[0]);
-                $scope.minor = parseInt($scope.version.toString()[2]);
+                $scope.major = parseInt($scope.version[0]);
+                $scope.minor = parseInt($scope.version[2]);
                 $scope.next_minor = $scope.minor + 1;
                 $scope.next_version = $scope.major + ($scope.next_minor/10);
             };

--- a/3.0/index.html
+++ b/3.0/index.html
@@ -144,9 +144,9 @@ except ImportError:
         .controller('wheelCtrl', function ($scope, $http) {
             $scope.init = function() {
                 $scope.eol = '27 June 2009';
-                $scope.version = 3.0;
-                $scope.major = parseInt($scope.version.toString()[0]);
-                $scope.minor = parseInt($scope.version.toString()[2]);
+                $scope.version = '3.0';
+                $scope.major = parseInt($scope.version[0]);
+                $scope.minor = parseInt($scope.version[2]);
                 $scope.next_minor = $scope.minor + 1;
                 $scope.next_version = $scope.major + ($scope.next_minor/10);
             };

--- a/3.1/index.html
+++ b/3.1/index.html
@@ -144,9 +144,9 @@ except ImportError:
         .controller('wheelCtrl', function ($scope, $http) {
             $scope.init = function() {
                 $scope.eol = '9 April 2012';
-                $scope.version = 3.1;
-                $scope.major = parseInt($scope.version.toString()[0]);
-                $scope.minor = parseInt($scope.version.toString()[2]);
+                $scope.version = '3.1';
+                $scope.major = parseInt($scope.version[0]);
+                $scope.minor = parseInt($scope.version[2]);
                 $scope.next_minor = $scope.minor + 1;
                 $scope.next_version = $scope.major + ($scope.next_minor/10);
             };

--- a/3.2/index.html
+++ b/3.2/index.html
@@ -144,9 +144,9 @@ except ImportError:
         .controller('wheelCtrl', function ($scope, $http) {
             $scope.init = function() {
                 $scope.eol = '27 February 2016';
-                $scope.version = 3.2;
-                $scope.major = parseInt($scope.version.toString()[0]);
-                $scope.minor = parseInt($scope.version.toString()[2]);
+                $scope.version = '3.2';
+                $scope.major = parseInt($scope.version[0]);
+                $scope.minor = parseInt($scope.version[2]);
                 $scope.next_minor = $scope.minor + 1;
                 $scope.next_version = $scope.major + ($scope.next_minor/10);
             };

--- a/3.3/index.html
+++ b/3.3/index.html
@@ -143,8 +143,8 @@ except ImportError:
             $scope.init = function() {
                 $scope.eol = '29 September 2017';
                 $scope.version = '3.3';
-                $scope.major = parseInt($scope.version.toString()[0]);
-                $scope.minor = parseInt($scope.version.toString()[2]);
+                $scope.major = parseInt($scope.version[0]);
+                $scope.minor = parseInt($scope.version[2]);
                 $scope.next_minor = $scope.minor + 1;
                 $scope.next_version = $scope.major + ($scope.next_minor/10);
             };


### PR DESCRIPTION
https://hugovk.github.io/drop-python/3.0/ was showing like:

![image](https://user-images.githubusercontent.com/1324225/37648672-4a4a0c02-2c38-11e8-9196-875521762ab5.png)

Instead of:

![image](https://user-images.githubusercontent.com/1324225/37648749-7d1cb4d6-2c38-11e8-8f6a-5b51972f8fe1.png)


Because it was indexing into the JSON at `packages[version]` as `packages[3]` not `packages['3.0']`

