### PR TITLE
Update classifying

### DIFF
--- a/test_utils.py
+++ b/test_utils.py
@@ -103,6 +103,23 @@ class TestClassifiersSupport(unittest.TestCase):
         # Assert
         self.assertEqual(has_support, "maybe")
 
+    def test_maybe_support_for_3x(self):
+        # Arrange
+        # We have major but no major.minor
+        classifiers = [
+            "Programming Language :: Python :: 2.4",
+            "Programming Language :: Python :: 2.5",
+            "Programming Language :: Python :: 2.6",
+            "Programming Language :: Python :: 2.7",
+            "Programming Language :: Python :: 3",
+        ]
+
+        # Act
+        has_support = utils.classifiers_support(classifiers, "3.4")
+
+        # Assert
+        self.assertEqual(has_support, "maybe")
+
 
 class TestRequiresPythonSupports(unittest.TestCase):
     def test_has_support(self):

--- a/test_utils.py
+++ b/test_utils.py
@@ -76,7 +76,7 @@ class TestClassifiersSupport(unittest.TestCase):
         has_support = utils.classifiers_support(classifiers, "2.6")
 
         # Assert
-        self.assertEqual(has_support, "no")
+        self.assertEqual(has_support, "maybe")
 
     def test_maybe_support_or_any_major_minor(self):
         # Arrange
@@ -116,6 +116,20 @@ class TestClassifiersSupport(unittest.TestCase):
 
         # Act
         has_support = utils.classifiers_support(classifiers, "3.4")
+
+        # Assert
+        self.assertEqual(has_support, "maybe")
+
+    def test_maybe_support_for_2x(self):
+        # Arrange
+        # We have major but no major.minor
+        classifiers = [
+            "Programming Language :: Python",
+            "Programming Language :: Python :: 3",
+        ]
+
+        # Act
+        has_support = utils.classifiers_support(classifiers, "2.6")
 
         # Assert
         self.assertEqual(has_support, "maybe")

--- a/utils.py
+++ b/utils.py
@@ -92,19 +92,26 @@ def requires_python_supports(requires_python, version):
 def classifiers_support(classifiers, version):
     """Do these classifiers support this Python version?"""
     desired_classifier = CLASSIFIER.format(version)
+    major, minor = version.split(".")
+    some_version_listed = False
 
-    # Explicit support
+    # Explicit major.minor support
     if desired_classifier in classifiers:
         return "yes"
 
     # Check if classifiers are explicit.
-    # Only report "no" when at least one major.minor version is explicitly
+    # Only report "no" when at least one other major.minor version is explicitly
     # supported (but not the desired one).
+    # ie. major and major.other present, but major.minor is missing.
     for classifier in classifiers:
-        if CLASSIFIER.format("2.") in classifier:
+        if "{}.".format(major) in classifier:
             return "no"
-        if CLASSIFIER.format("3.") in classifier:
-            return "no"
+        if "Programming Language :: Python " in classifier:
+            some_version_listed = True
+
+    # We have at least some version listed, but not even this major
+    if some_version_listed and CLASSIFIER.format(major) not in classifiers:
+        return "no"
 
     # Otherwise?
     return "maybe"

--- a/utils.py
+++ b/utils.py
@@ -106,8 +106,11 @@ def classifiers_support(classifiers, version):
     for classifier in classifiers:
         if "{}.".format(major) in classifier:
             return "no"
-        if "Programming Language :: Python " in classifier:
+        if "Programming Language :: Python ::" in classifier:
             some_version_listed = True
+
+    if major == "2" and "Programming Language :: Python" in classifiers:
+        return "maybe"
 
     # We have at least some version listed, but not even this major
     if some_version_listed and CLASSIFIER.format(major) not in classifiers:


### PR DESCRIPTION
Some classifiers such as this:
```
"Programming Language :: Python :: 2.6",
"Programming Language :: Python :: 2.7",
"Programming Language :: Python :: 3"
```
were being interpreted as 3.2 not supported, when really 3.2 might be supported.