### PR TITLE
Add Python 2.7 and 3.4 to frontpage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
 cache: pip
+dist: xenial
 
 # Supported CPython versions:
 # https://en.wikipedia.org/wiki/CPython#Version_history
 python:
  - 3.6
+ - 3.7
 
 install:
  - pip install pycodestyle pyflakes

--- a/index.html
+++ b/index.html
@@ -25,10 +25,19 @@
                 <object data="2.6/wheel.svg" type="image/svg+xml" width="380" height="380" class="center-block"></object>
             </div>
             <div class="col-sm-6">
+                <h2 id="2.7"><a href="2.7">Python 2.7</a></h2>
+                <object data="2.7/wheel.svg" type="image/svg+xml" width="380" height="380" class="center-block"></object>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-sm-6">
                 <h2 id="3.2"><a href="3.2">Python 3.2</a></h2>
                 <object data="3.2/wheel.svg" type="image/svg+xml" width="380" height="380" class="center-block"></object>
             </div>
-        </div>
+            <div class="col-sm-6">
+                <h2 id="3.3"><a href="3.3">Python 3.3</a></h2>
+                <object data="3.3/wheel.svg" type="image/svg+xml" width="380" height="380" class="center-block"></object>
+            </div>
         <div class="row">
             <div class="col-sm-6">
 
@@ -52,8 +61,8 @@
             </div>
 
             <div class="col-sm-6">
-                <h2 id="3.3"><a href="3.3">Python 3.3</a></h2>
-                <object data="3.3/wheel.svg" type="image/svg+xml" width="380" height="380" class="center-block"></object>
+                <h2 id="3.4"><a href="3.4">Python 3.4</a></h2>
+                <object data="3.4/wheel.svg" type="image/svg+xml" width="380" height="380" class="center-block"></object>
             </div>
 
         </div>


### PR DESCRIPTION
Fixes #27.

Version | Release date | Supported until
--- | ---------- | ----------
2.5 | 2006-09-19 | 2011-05-26
2.6 | 2008-10-01 | 2013-10-29
2.7 | 2010-07-03 | 2020-01-01
3.0 | 2008-12-03 | 2009-06-27
3.1 | 2009-06-27 | 2012-04-09
3.2 | 2011-02-20 | 2016-02-27
3.3 | 2012-09-29 | 2017-09-29
3.4 | 2014-03-16 | 2019-03-16

https://en.wikipedia.org/wiki/CPython#Version_history
