### PR TITLE
Scripts for plotting history of data from the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules
 
 # Generated files
+history.jsonl
+history.png
 results*.json
 top-pypi-packages.json
 wheel*.png

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.1.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
@@ -21,7 +21,7 @@ repos:
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.4
+    rev: v2.1.0
     hooks:
       - id: seed-isort-config
 
@@ -31,12 +31,12 @@ repos:
       - id: isort
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.4.4
+    rev: v1.5.1
     hooks:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ python:
  - 3.6
  - 3.7
  - 3.8
+ - 3.9-dev
 
 install:
  - pip install flake8
  - pip install -r requirements.txt
+ - pip install -r history-requirements.txt
  - npm install svgexport -g
 
 script:
@@ -20,6 +22,10 @@ script:
 
  # Test run
  - ./build.sh
+
+# History charts
+ - python history_get.py -n 10
+ - python history_plot.py
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ script:
  # Test run
  - ./build.sh
 
-# History charts
+ # History charts
+ - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+ - git fetch origin
  - python history_get.py -n 10
  - python history_plot.py
 

--- a/history-requirements.txt
+++ b/history-requirements.txt
@@ -1,0 +1,5 @@
+gitpython
+jsonlines
+matplotlib
+termcolor
+tqdm

--- a/history_get.py
+++ b/history_get.py
@@ -1,0 +1,119 @@
+"""
+Go through the drop-python commit history and create history.jsonl of lines like this:
+
+{"date": "2017-10-22 18:44:21+03:00", "drop_totals": {"3.2":204, "3.3":102, "2.6":105}}
+{"date": "2017-10-22 17:44:22+03:00", "drop_totals": {"3.2":203, "3.3":102, "2.6":105}}
+
+Usage:
+pip install -r history-requirements.txt
+python3 history_get.py  # creates/updates history.jsonl
+"""
+import argparse
+import json
+
+import git  # pip install gitpython
+import jsonlines  # pip install jsonlines
+from tqdm import tqdm  # pip install tqdm
+
+# from pprint import pprint  # noqa: F401
+
+
+def load_from_file(file_name):
+    try:
+        with open(file_name) as f:
+            packages = json.load(f)
+        return packages
+
+    except json.decoder.JSONDecodeError:
+        return None
+
+
+def do_json_file():
+    data = load_from_file("results.json")
+    do_json(data)
+
+
+def do_json(data):
+    packages = data["data"]
+
+    drop_totals = dict()
+    for package in packages:
+        for key, value in package.items():
+            if key in ["downloads", "name", "value"]:
+                continue
+            thingy = int(value["dropped_support"] == "yes")
+            try:
+                drop_totals[key] += thingy
+            except KeyError:
+                drop_totals[key] = thingy
+
+    return drop_totals
+
+
+def load_jsonlines(file_name):
+    with jsonlines.open(file_name) as reader:
+        lines = [line for line in reader]
+    return lines
+
+
+def append_jsonlines(file_name, lines):
+    with jsonlines.open(file_name, mode="a") as writer:
+        for line in lines:
+            writer.write(line)
+
+
+DATE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-n",
+        "--number",
+        type=int,
+        help="Number of commits to process. For testing, default: all",
+    )
+    args = parser.parse_args()
+    print(args.number)
+
+    try:
+        old_lines = load_jsonlines("history.jsonl")
+    except FileNotFoundError:
+        old_lines = []
+    old_dates = {d["date"] for d in old_lines}
+
+    repo = git.Repo(".")
+    origin = repo.remote("origin")
+    print("Fetch origin/gh-pages...")
+    origin.fetch("gh-pages")
+
+    print("Get data...")
+    new_lines = []
+
+    commits = list(repo.iter_commits("origin/gh-pages"))
+    if args.number:
+        commits = commits[: args.number]
+    commits.reverse()  # oldest first
+    for commit in tqdm(commits):
+
+        if str(commit.authored_datetime) in old_dates:
+            continue
+
+        try:
+            target_file = commit.tree / "results.json"
+        except KeyError:
+            # eg. "Blob or Tree named 'results.json' not found"
+            continue
+        data = target_file.data_stream.read()
+        data = json.loads(data)
+        drop_totals = do_json(data)
+        new_lines.append(
+            {"date": str(commit.authored_datetime), "drop_totals": drop_totals}
+        )
+
+    append_jsonlines("history.jsonl", new_lines)
+    print(f"Updated with {len(new_lines)} commits")
+
+
+if __name__ == "__main__":
+    main()

--- a/history_plot.py
+++ b/history_plot.py
@@ -1,0 +1,137 @@
+"""
+Take history.jsonl from history_get.py and plot it
+
+Usage:
+
+# Prep
+pip install -r history-requirements.txt
+python3 history_get.py  # creates/updates history.jsonl
+
+# All available data
+python3 history_plot.py && open history.png
+
+# Subset
+python3 history_plot.py -v 2.6 2.7 3.3 3.4 3.5 && open history.png
+"""
+import argparse
+import hashlib
+from pprint import pprint  # noqa: F401
+
+from termcolor import colored  # pip install termcolor
+
+from history_get import load_jsonlines
+
+
+def dopplr(name):
+    """
+    Take the MD5 digest of a name,
+    convert it to hex and take the
+    first 6 characters as an RGB value.
+    """
+    # Tweak "2.8" because it's too close in colour to "3.5"
+    if name == "2.8":
+        name = "python 2.8"
+
+    return "#" + hashlib.sha224(name.encode()).hexdigest()[:6]
+
+
+def make_chart(dates, totals):
+    # x: list of dates
+    # y: totals for each version
+    import matplotlib.pyplot as plt  # pip install matplotlib
+    import matplotlib.ticker as plticker
+
+    # "2020-01-26 22:35:22+02:00" -> "2020-01-26"
+    dates = [date.split()[0] for date in dates]
+
+    fig, ax = plt.subplots()
+
+    print("Plot...")
+    for k, v in totals.items():
+        print(k)
+        ax.plot(dates, v, label=k, color=dopplr(k))
+
+    plt.xticks(rotation=90)
+
+    # Tweak spacing to prevent clipping of tick-labels
+    plt.subplots_adjust(bottom=0.2)
+
+    # Shrink current axis by 20% so legend is outside chart
+    box = ax.get_position()
+    ax.set_position([box.x0, box.y0, box.width * 0.9, box.height])
+
+    # Put a legend to the right of the current axis
+    ax.legend(
+        loc="center left", bbox_to_anchor=(1, 0.5),
+    )
+
+    # This locator puts ticks at regular intervals
+    loc = plticker.MultipleLocator(base=48.0)
+    ax.xaxis.set_major_locator(loc)
+
+    outfile = "history.png"
+    print(colored(outfile, "green"))
+    plt.savefig(outfile, dpi=96 * 2.5)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("-v", "--versions", nargs="+", help="Show only these versions")
+    args = parser.parse_args()
+
+    # Each line looks like:
+    # {
+    #  "date": "2020-01-26 23:35:22+02:00",
+    #  "drop_totals": {"2.0": 348, "2.1": 348, "2.2": 348, "2.3": 348, "2.4": 342, ...}
+    # }
+    lines = load_jsonlines("history.jsonl")
+
+    #  First 3-4 days of data is junk, ditch it
+    lines = [line for line in lines if line["date"] > "2017-10-11 20:44:23+03:00"]
+
+    # Ditch first few days for some due to bug fixes causing a sudden dip
+    for line in lines:
+        if line["date"] <= "2017-10-24 23:44:27+03:00":
+            line["drop_totals"].pop("2.6", None)
+            line["drop_totals"].pop("3.2", None)
+        if line["date"] <= "2018-09-06 13:35:20+03:00":
+            line["drop_totals"].pop("3.4", None)
+
+    # Sort by date
+    lines = sorted(lines, key=lambda k: k["date"])
+    print("Number of lines:", len(lines))
+
+    # First get a list of all versions, as not every data point has every version
+    if args.versions:
+        all_versions = args.versions
+    else:
+        all_versions = set()
+        for line in lines:
+            all_versions.update(line["drop_totals"].keys())
+        all_versions = sorted(all_versions)
+    print("All versions: ", all_versions)
+
+    print("Prep data...")
+    dates = []
+    totals = dict()
+    for line in lines:
+        dates.append(line["date"])
+
+        for version in all_versions:
+            try:
+                version_total = line["drop_totals"][version]
+            except KeyError:
+                version_total = None
+
+            try:
+                totals[version].append(version_total)
+            except KeyError:
+                totals[version] = [version_total]
+
+    make_chart(dates, totals)
+
+
+if __name__ == "__main__":
+    main()

--- a/history_plot.py
+++ b/history_plot.py
@@ -66,8 +66,14 @@ def make_chart(dates, totals):
     )
 
     # This locator puts ticks at regular intervals
-    loc = plticker.MultipleLocator(base=48.0)
+    loc = plticker.MultipleLocator(base=50)
     ax.xaxis.set_major_locator(loc)
+    loc = plticker.MultipleLocator(base=60)
+    ax.yaxis.set_major_locator(loc)
+
+    plt.suptitle("Dropped Python versions")
+    plt.title("By the top 360 packages downloaded from PyPI", fontsize=10)
+    plt.ylabel("Packages")
 
     outfile = "history.png"
     print(colored(outfile, "green"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target_version = ["py36"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 max_line_length = 88
 
 [tool:isort]
-known_third_party = pip,pytz,requests
+known_third_party = git,jsonlines,pip,pytz,requests,termcolor,tqdm
 force_grid_wrap = 0
 include_trailing_comma = True
 line_length = 88


### PR DESCRIPTION
```console
$ python history_get.py
None
Fetch origin/gh-pages...
Get data...
100%|████████████████████████████████████████████████████████████████████████████████| 20573/20573 [00:04<00:00, 4871.43it/s]
Updated with 8 commits
```
```console
$ python history_plot.py
Number of lines: 20301
All versions:  ['2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '3.5']
Prep data...
Plot...
2.0
2.1
2.2
2.3
2.4
2.5
2.6
2.7
3.0
3.1
3.2
3.3
3.4
3.5
history.png
```

![image](https://user-images.githubusercontent.com/1324225/75705429-024a7180-5cc4-11ea-876d-4ac03e776e6b.png)

```console
$ python history_plot.py -v 2.6 2.7 3.2 3.3 3.4
Number of lines: 20301
All versions:  ['2.6', '2.7', '3.2', '3.3', '3.4']
Prep data...
Plot...
2.6
2.7
3.2
3.3
3.4
history.png
```
![image](https://user-images.githubusercontent.com/1324225/75705661-7d138c80-5cc4-11ea-889a-c0f6c0f4ce31.png)


* [x] TODO Title, axis labels...