### PR TITLE
Reduce hardcoding by fetching EOL dates from endoflife.date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 # Generated files
 history.jsonl
 history.png
+python-eol.json
 results*.json
 top-pypi-packages.json
 wheel*.png

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,9 @@ git pull origin master
 # Fetch fresh copy of top packages
 wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json -O top-pypi-packages.json
 
+# Fetch Python EOL dates
+wget https://endoflife.date/api/python.json -O python-eol.json
+
 # Generate the files
 python3 generate.py --version 2.{0,1,2,3,4,5,6,7} 3.{0,1,2,3,4,5,6}
 


### PR DESCRIPTION
Use the API at https://endoflife.date/python to read available EOL dates from the JSON at https://endoflife.date/api/python.json
