### PR TITLE
Run daily instead of hourly

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Then visit http://localhost:8000/
 
 ## How to deploy
 
-Make sure we're on `main` and run `crontask.sh` hourly from cron.
+Make sure we're on `main` and run `crontask.sh` daily from cron.
 
 ## Thanks
 


### PR DESCRIPTION
I couldn't log in to the server because this repo was taking too much space! I restored a backup, deleted the repo and re-cloned with shallow depth. Now using 50% space.

We also don't need so many updates. Crontab adjusted to deploy daily at 7am Helsinki time.
