### PR TITLE
Update links for Python version changes

### DIFF
--- a/template.py
+++ b/template.py
@@ -108,13 +108,13 @@ set([1, 2, 3])  # This can be replaced...
     "3.9": {
         "reasons": """
                     <li><a href="https://github.com/jugmac00/python-version-cheat-sheet#python-310">use <code>match</code> statement and write union types as <code>X | Y</code></a></li>
-                    <li><a href="https://docs.python.org/3/whatsnew/3.9.html">And more!</a></li>
+                    <li><a href="https://docs.python.org/3/whatsnew/3.10.html">And more!</a></li>
     """  # noqa: E501
     },
     "3.10": {
         "reasons": """
                     <li><a href="https://github.com/jugmac00/python-version-cheat-sheet#python-311"><code>tomllib</code> in the stdlib, exception groups and except*</a></li>
-                    <li><a href="https://docs.python.org/3/whatsnew/3.10.html">And more!</a></li>
+                    <li><a href="https://docs.python.org/3/whatsnew/3.11.html">And more!</a></li>
     """  # noqa: E501
     },
 }


### PR DESCRIPTION
"what's new" link were pointing to the dropped version for 3.9 & 3.10